### PR TITLE
Fix min to max and other minor fix

### DIFF
--- a/src/pds/llm/Wiki2Vec.py
+++ b/src/pds/llm/Wiki2Vec.py
@@ -4,24 +4,35 @@ import numpy as np
 from numpy.linalg import norm
 
 
-MODEL_FILE = '/Users/arobinson/Documents/enwiki_20180420_100d.pkl'
+MODEL_FILE = './enwiki_20180420_100d.pkl'
 wiki2vec = Wikipedia2Vec.load(MODEL_FILE)
-urls = [ 'https://atmos.nmsu.edu/PDS/data/PDS4/saturn_iono/data/rss_s10_r007_ne_e.xml'
+urls = [ 'https://atmos.nmsu.edu/PDS/data/PDS4/saturn_iono/data/rss_s10_r007_ne_e.xml',
             'https://planetarydata.jpl.nasa.gov/img/data/nsyt/insight_cameras/data/sol/0024/mipl/edr/icc/C000M0024_598662821EDR_F0000_0558M2.xml']
-def get_embeddings(urls, MODEL_FILE, clean_tokens):
-    embedding_vectors = []
+
+
+def get_embeddings(urls, MODEL_FILE):
+    embedding_vectors = {}
     for url in urls:
         tokens = tokenize_pds4_xml_files_AR(url, clean_tokens=[])
         #Convert tokens to vectors
-        vectors = [wiki2vec.get_word_vector(tokens)for token in tokens if token in wiki2vec.vocab]
-        embedding_vectors.append(vectors)
-        print(embedding_vectors)
-        return(clean_tokens, embedding_vectors)
+        vectors = []
+        for token in tokens:
+            try:
+                vectors.append(wiki2vec.get_word_vector(token))
+            except KeyError:
+                pass
+        # not sure if `token in wiki2vec.dictionary` works as we want it to
+        #vectors = [wiki2vec.get_word_vector(token) for token in tokens if token in wiki2vec.dictionary]
+        embedding_vectors[url] = vectors
+
+    return embedding_vectors
+
 
 def cosine_similarity(a, b):
     return np.dot(a, b) / (norm(a) * norm(b))
 
-def cosine_similarity_of_terms(clean_tokens, embedding_vectors):
+
+def cosine_similarity_of_terms(embedding_vectors):
     search_terms = [
         'soccer',
         'saturn',
@@ -40,22 +51,31 @@ def cosine_similarity_of_terms(clean_tokens, embedding_vectors):
         'image'
     ]
     similarities = []
+    search_embeddings = {}
+    max_cos_sim = {}
     for term in search_terms:
-        term_vector = wiki2vec.get_word_vector(term)
-        min_cos_sim = np.inf
-        for emb_set in embedding_vectors:
+        search_embeddings[term] = []
+        for token in term.split(" "):
+            try:
+                search_embeddings[term].append(wiki2vec.get_word_vector(token))
+            except KeyError:
+                print(f"term {token} not found in model")
+                pass
+        max_cos_sim[term] = {}
+        for url, emb_set in embedding_vectors.items():
+            cos_sim = []
             for emb in emb_set:
-                cos_sim = cosine_similarity(term_vector, emb)
-                min_cos_sim = min(min_cos_sim, cos_sim)
-        similarities.append((term, min_cos_sim))
-    return similarities
+                for search_emb in search_embeddings[term]:
+                   cos_sim.append(cosine_similarity(search_emb, emb))
+            max_cos_sim[term][url] = max(cos_sim) if len(cos_sim) > 0 else np.nan
+        print(f'{term} {[v for v in max_cos_sim[term].values()]}')
+    return max_cos_sim
 
 
 def main():
-    clean_tokens, embedding_vectors = get_embeddings(urls, MODEL_FILE)
-    similarities = cosine_similarity_of_terms(clean_tokens, embedding_vectors)
-    for term, similarity in similarities:
-        print(f"Cosine similarity for '{term}: {similarity}")
+    embedding_vectors = get_embeddings(urls, MODEL_FILE)
+    similarities = cosine_similarity_of_terms(embedding_vectors)
+
 
 if __name__ == '__main__':
     main()

--- a/src/pds/llm/sbert_test.py
+++ b/src/pds/llm/sbert_test.py
@@ -50,12 +50,12 @@ def cosine_similarity(a, b):
 
 print("search term\turl1\turl2")
 for s, se in search_terms_embeddings.items():
-    min_cos_sims = []
+    max_cos_sims = []
     for p, les in label_embeddings.items():
         cos_sims = [cosine_similarity(se, le) for le in les]
-        min_cos_sims.append(str(min(cos_sims)))
+        max_cos_sims.append(str(max(cos_sims)))
     tab = '\t'
-    print(f"{s}{tab}{tab.join(min_cos_sims)}")
+    print(f"{s}{tab}{tab.join(max_cos_sims)}")
 
 print("that's it !")
 

--- a/src/pds/llm/tokenization/tokenize.py
+++ b/src/pds/llm/tokenization/tokenize.py
@@ -3,15 +3,14 @@ import xmltodict
 import json
 from nltk.tokenize import word_tokenize, sent_tokenize
 
-def tokenize_pds4_xml_files_AR(urls, clean_tokens):
-    response = requests.get(urls)
+def tokenize_pds4_xml_files_AR(url, clean_tokens):
+    response = requests.get(url)
     xml_data = response.text
     xml_dict = xmltodict.parse(xml_data)
     xml_string = json.dumps(xml_dict)
     sentences = sent_tokenize(xml_string)
     tokens = [word_tokenize(sentence) for sentence in sentences]
-    clean_tokens = []
-    clean_tokens = [token for sentence_tokens in tokens for token in sentence_tokens if
+    clean_tokens = [token.lower() for sentence_tokens in tokens for token in sentence_tokens if
                     '"' not in token and ',' not in token and '@' not in
                     token and '`' not in token and ':' not in token and '{' not in
                     token and "'" not in token and '.' not in token and ';' not in


### PR DESCRIPTION
## 🗒️ Summary
I made minor fix for wiki2vec so that it can work and then I realize we must get the maximum similarity instead of the minimum to get something relevant for a search match.

## ⚙️ Test Data and/or Report
Now we have interesting results for wiki2vec:
```
soccer [0.37784123, 0.4508011]
saturn [1.0, 0.67866164]
cassini [1.0, 0.6619328]
term casinni not found in model
casinni [nan, nan]
huygens [0.6537399, 0.6411508]
orbiter [1.0, 0.86500156]
rss [1.0000001, 0.5660705]
ionospheric [1.0, 0.6641813]
ionosphere [0.99999994, 0.6911686]
electron density [1.0000001, 0.7045567]
insight [0.58462083, 0.99999994]
context camera [0.99999994, 0.99999994]
camera [0.5541305, 0.99999994]
mars [0.7524765, 1.0]
image [0.5674547, 1.0]

```

And sbert:

```
search term	url1	url2
soccer	0.11978036	0.19816406
saturn	0.59380704	0.34539118
cassini	0.56171	0.2343969
casinni	0.17423473	0.14633963
huygens	0.2884251	0.17699014
orbiter	0.42409316	0.40223986
rss	0.4095342	0.2766975
ionospheric	0.561024	0.42074218
ionosphere	0.58294785	0.32476434
electron density	0.5330929	0.23959345
insight	0.23256068	0.4713701
context camera	0.24521038	0.5074566
camera	0.2444182	0.4522183
mars	0.31934488	0.5289796
image	0.19510958	0.432962`
```

